### PR TITLE
Renames variable to $_seed-color-scheme

### DIFF
--- a/scss/pack/seed-color-scheme/_config.scss
+++ b/scss/pack/seed-color-scheme/_config.scss
@@ -1,7 +1,7 @@
 // Color :: Config
 
 // Default color scheme map
-$seed-color-scheme: (
+$_seed-color-scheme: (
   black: "#000",
   white: "#fff"
 ) !global;

--- a/scss/pack/seed-color-scheme/functions/_color.scss
+++ b/scss/pack/seed-color-scheme/functions/_color.scss
@@ -7,7 +7,7 @@
   }
 
   // Default color scheme map
-  $map: $seed-color-scheme;
+  $map: $_seed-color-scheme;
   @each $key in $keys {
     $map: map-get($map, $key);
   }

--- a/scss/pack/seed-color-scheme/mixins/_color.scss
+++ b/scss/pack/seed-color-scheme/mixins/_color.scss
@@ -5,7 +5,7 @@
 
 @mixin _color($maps...) {
   // Default map
-  $scheme: $seed-color-scheme;
+  $scheme: $_seed-color-scheme;
   // Reset if invalid
   @if (type-of($scheme) != "map") {
     $scheme: (
@@ -13,5 +13,5 @@
     );
   }
   // Quietly set the color-scheme
-  $seed-color-scheme: _extend($scheme, $maps...) !global;
+  $_seed-color-scheme: _extend($scheme, $maps...) !global;
 }

--- a/test/functions/_color.scss
+++ b/test/functions/_color.scss
@@ -7,7 +7,7 @@
   @include test("should get the correct color from a simple map") {
 
     @import "./scss/pack/seed-color-scheme/functions/_color";
-    $seed-color-scheme: (
+    $_seed-color-scheme: (
       primary: blue,
       secondary: red
     );
@@ -22,7 +22,7 @@
   @include test("should get the correct color from a nested map") {
 
     @import "./scss/pack/seed-color-scheme/functions/_color";
-    $seed-color-scheme: (
+    $_seed-color-scheme: (
       primary: (
         blue: (
           100: blue
@@ -39,7 +39,7 @@
   @include test("should fallback to default color if key is not defined") {
 
     @import "./scss/pack/seed-color-scheme/functions/_color";
-    $seed-color-scheme: (
+    $_seed-color-scheme: (
       primary: (
         blue: (
           default: purple,
@@ -57,7 +57,7 @@
   @include test("should fallback to first key if key and default is not defined") {
 
     @import "./scss/pack/seed-color-scheme/functions/_color";
-    $seed-color-scheme: (
+    $_seed-color-scheme: (
       primary: (
         blue: (
           100: light-blue,
@@ -74,11 +74,11 @@
 
   @include test("should get correct color of a newly updated map") {
 
-    $seed-color-scheme: (
+    $_seed-color-scheme: (
       primary: red
     );
     @import "./scss/pack/seed-color-scheme/functions/_color";
-    $seed-color-scheme: (
+    $_seed-color-scheme: (
       primary: blue
     );
 

--- a/test/mixins/_color.scss
+++ b/test/mixins/_color.scss
@@ -5,7 +5,7 @@
 @import "./scss/pack/seed-color-scheme/mixins/color";
 
 // Set the default color scheme
-$seed-color-scheme: (
+$_seed-color-scheme: (
   primary: blue,
   secondary: red
 );
@@ -14,7 +14,7 @@ $seed-color-scheme: (
 
   @include test("should correctly handle initial blank color scheme") {
 
-    $seed-color-scheme: () !global;
+    $_seed-color-scheme: () !global;
     $map: (
       blue: blue
     );


### PR DESCRIPTION
The global color scheme variable shouldn't be adjusted directly, but instead with the `_color()` function. Renaming it to `$_seed-color-scheme` helps indicate that it is "private", although it technically isn't.
