### PR TITLE
Add default color scheme with default namespaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ var path = require('path');
 var pathfinder = require('sass-pathfinder');
 
 var files = pathfinder([
-  require('seed-dash'),
   path.join(__dirname, 'scss'),
 ]);
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "seed-bistro": "0.1.2"
   },
   "dependencies": {
-    "sass-pathfinder": "0.0.5",
-    "seed-dash": "0.0.1"
+    "sass-pathfinder": "0.0.5"
   }
 }

--- a/scss/pack/seed-color-scheme/_config.scss
+++ b/scss/pack/seed-color-scheme/_config.scss
@@ -1,9 +1,195 @@
 // Color :: Config
 
+// Dependencies
+@import "./functions/color";
+@import "./mixins/color";
+
 // Default color scheme map
 @if not global-variable-exists(SEED_COLOR_SCHEME__GLOBAL) {
+  // Base
   $SEED_COLOR_SCHEME__GLOBAL: (
+    white: #fff,
     black: #000,
-    white: #fff
   ) !global;
+
+  // Colors
+  @include _color((
+    // Primary
+    blue: (
+      100: #f7fcfe,
+      200: #daf1ff,
+      300: #aedfff,
+      400: #71bff1,
+      500: #3197d6,
+      600: #237ab3,
+      700: #1f5e89,
+      800: #194c6e,
+      900: #143d57
+    ),
+
+    charcoal: (
+      200: #93a1af,
+      300: #72808e,
+      400: #4f5d6b,
+      500: #394956,
+      600: #2a3b47,
+      700: #253540,
+      800: #1d2b36
+    ),
+
+    grey: (
+      200: #f9fafa,
+      300: #f1f3f5,
+      400: #e3e8eb,
+      500: #d6dde3,
+      600: #c1cbd4,
+      700: #b4c0ca,
+      800: #a5b2bd
+    ),
+
+    // Secondary
+    yellow: (
+      100: #fffdf6,
+      200: #fff6e2,
+      300: #ffe8b5,
+      400: #ffd56d,
+      500: #ffc646,
+      600: #f5b126,
+      700: #d79400,
+      800: #b37100,
+      900: #875200
+    ),
+
+    green: (
+      100: #fafdfb,
+      200: #e4fbe6,
+      300: #c4f0ce,
+      400: #81dc9e,
+      500: #4bc27d,
+      600: #3cb170,
+      700: #2f9f62,
+      800: #228350,
+      900: #23633e
+    ),
+
+    red: (
+      100: #fef7f6,
+      200: #ffe3e2,
+      300: #ffa2a2,
+      400: #f45b55,
+      500: #e52f28,
+      600: #d21b14,
+      700: #ba1f19,
+      800: #9d1f1a,
+      900: #731814
+    ),
+
+    purple: (
+      100: #fbfbfe,
+      200: #eaeafc,
+      300: #d1d2f6,
+      400: #a3a4f3,
+      500: #7e80e7,
+      600: #696aca,
+      700: #585b9e,
+      800: #45467d,
+      900: #383966
+    ),
+
+    orange: (
+      100: #fff8f2,
+      200: #ffead8,
+      300: #ffd3ae,
+      400: #ffa75a,
+      500: #ff9139,
+      600: #e87800,
+      700: #c76400,
+      800: #a45300,
+      900: #813c00
+    ),
+  ));
+
+  // Namespace: Brand
+  @include _color((
+    brand: (
+      primary: _color(blue, 500),
+      danger: _color(red, 500),
+      error: _color(red, 500),
+      info: _color(blue, 500),
+      success: _color(green, 500),
+      warning: _color(yellow, 500),
+    ),
+  ));
+
+  // Namespace: Background
+  @include _color((
+    background: (
+      body: #fff,
+      ui: (
+        default: #fff,
+        lighter: _color(grey, 200),
+        light: _color(grey, 300),
+      ),
+    ),
+  ));
+
+  // Namespace: Border
+  @include _color((
+    border: (
+      default: _color(grey, 400),
+      divider: _color(grey, 300),
+      ui: (
+        default: _color(grey, 500),
+        dark: _color(grey, 600),
+      ),
+    ),
+  ));
+
+  // Namespace: Text
+  @include _color((
+    text: (
+      default: _color(charcoal, 600),
+      subtle: _color(charcoal, 400),
+      muted: _color(charcoal, 200),
+    ),
+  ));
+
+  // Namespace: Link
+  @include _color((
+    link: (
+      default: _color(blue, 500),
+      hover: _color(blue, 400),
+    ),
+  ));
+
+  // Namespace: States
+  @include _color((
+    state: (
+      danger: (
+        background-color: _color(red, 200),
+        border-color: _color(red, 500),
+        color: _color(red, 800)
+      ),
+      error: (
+        background-color: _color(red, 200),
+        border-color: _color(red, 500),
+        color: _color(red, 800)
+      ),
+      info: (
+        background-color: _color(blue, 200),
+        border-color: _color(blue, 500),
+        color: _color(blue, 800)
+      ),
+      success: (
+        background-color: _color(green, 200),
+        border-color: _color(green, 500),
+        color: _color(green, 800)
+      ),
+      warning: (
+        background-color: _color(yellow, 200),
+        border-color: _color(yellow, 500),
+        color: _color(yellow, 800)
+      ),
+    ),
+  ));
 }

--- a/scss/pack/seed-color-scheme/functions/_deep-extend.scss
+++ b/scss/pack/seed-color-scheme/functions/_deep-extend.scss
@@ -1,0 +1,48 @@
+// _deep-extend
+// Source
+// https://www.github.com/helpscout/seed-dash
+// Modified version of _extend
+
+@function _deep-extend($map, $maps...) {
+  $is_map: type-of($map) == "map";
+  $is_list: type-of($map) == "list";
+
+  @if not $is_map and not $is_list {
+    @error "_deep-extend: The argument must be a list or a map.";
+  }
+
+  $max: length($maps);
+
+  // extend lists
+  @if $is_list {
+    @for $i from 1 through $max {
+      $current: nth($maps, $i);
+
+      @if type-of($current) != "list" {
+        @error "_deep-extend: The second argument(s) must be a list.";
+      }
+      $map: join($map, $current);
+    }
+    @return $map;
+  }
+
+  // deep-extend maps
+  // Loop through all maps in $maps...
+  @for $i from 1 through $max {
+    // Store current map
+    $current: nth($maps, $i);
+
+    // If in deep mode, loop through all tuples in current map
+    @each $key, $value in $current {
+      // If value is a nested map and same key from map is a nested map as well
+      @if type-of($value) == "map" and type-of(map-get($map, $key)) == "map" {
+        // Recursive extend
+        $value: _deep-extend(map-get($map, $key), $value, true);
+      }
+      // Merge current tuple with map
+      $map: map-merge($map, ($key: $value));
+    }
+  }
+
+  @return $map;
+}

--- a/scss/pack/seed-color-scheme/mixins/_color.scss
+++ b/scss/pack/seed-color-scheme/mixins/_color.scss
@@ -1,7 +1,7 @@
 // Mixins :: _color
 
 // Dependencies
-@import "pack/seed-dash/_index";
+@import "../functions/deep-extend";
 
 @mixin _color($maps...) {
   // Default map
@@ -11,5 +11,5 @@
     @warn "seed-color-scheme: Argument must be a map.";
   }
   // Quietly set the color-scheme
-  $SEED_COLOR_SCHEME__GLOBAL: _extend($scheme, $maps...) !global;
+  $SEED_COLOR_SCHEME__GLOBAL: _deep-extend($scheme, $maps...) !global;
 }

--- a/test/color.js
+++ b/test/color.js
@@ -110,6 +110,28 @@ describe('seed-color-scheme: color', function() {
     expect($w.prop('color')).to.equal('#fff');
   });
 
+  it('should not change color if set after _color() is used', function() {
+    var output = styles(`
+      @include _color((
+        black: red,
+      ));
+      @include _color((
+        black: blue,
+      ));
+
+      .black {
+        color: _color(black);
+      }
+
+      @include _color((
+        black: yellow,
+      ));
+    `);
+    var $b = output.$('.black');
+
+    expect($b.prop('color')).to.equal('blue');
+  });
+
   it('should be able to add multiple schemes', function() {
     var output = styles(`
       $blue: (
@@ -218,5 +240,75 @@ describe('seed-color-scheme: color', function() {
     var $o = output.$('.element');
 
     expect($o.prop('color')).to.equal('blue');
+  });
+
+  it('should be able deep extend existing colors', function() {
+    var output = styles(`
+      $color: (
+        blue: (
+          100: yellow,
+        ),
+      );
+      @include _color($color);
+
+      .e1 {
+        color: _color(blue, 100);
+      }
+      .e2 {
+        color: _color(blue, 200);
+      }
+
+      @import "./_index";
+    `);
+    var $e1 = output.$('.e1');
+    var $e2 = output.$('.e2');
+
+    expect($e1.prop('color')).to.equal('yellow');
+    expect($e2.prop('color')).to.equal('#daf1ff');
+  });
+
+  it('should be able deep extend existing colors and add new colors', function() {
+    var output = styles(`
+      $color: (
+        blue: (
+          100: yellow,
+        ),
+        pink: pink,
+        fushia: (
+          ultimate: purple,
+        ),
+        red: red,
+      );
+      @include _color($color);
+
+      .e1 {
+        color: _color(blue, 100);
+      }
+      .e2 {
+        color: _color(blue, 200);
+      }
+      .e3 {
+        color: _color(pink);
+      }
+      .e4 {
+        color: _color(fushia, ultimate);
+      }
+      .e5 {
+        color: _color(red);
+      }
+
+      @import "./_index";
+    `);
+    var $e1 = output.$('.e1');
+    var $e2 = output.$('.e2');
+    var $e3 = output.$('.e3');
+    var $e4 = output.$('.e4');
+    var $e5 = output.$('.e5');
+
+    expect($e1.prop('color')).to.equal('yellow');
+    expect($e2.prop('color')).to.equal('#daf1ff');
+    expect($e3.prop('color')).to.equal('pink');
+    expect($e4.prop('color')).to.equal('purple');
+    expect($e5.prop('color')).to.equal('red');
   });
 });

--- a/test/color.scheme.js
+++ b/test/color.scheme.js
@@ -1,0 +1,92 @@
+// Test :: Mixin/Function :: Color Scheme
+/* globals describe: true, it: true */
+'use strict';
+
+var expect = require('chai').expect;
+var styles = require('./helper.styles');
+
+describe('seed-color-scheme: color: scheme', function() {
+  it('should have a default color palette', function() {
+    var output = styles(`
+      .blue {
+        color: _color(blue, 500);
+      }
+      .charcoal {
+        color: _color(charcoal, 500);
+      }
+      .grey {
+        color: _color(grey, 500);
+      }
+      .red {
+        color: _color(red, 500);
+      }
+      .yellow {
+        color: _color(yellow, 500);
+      }
+      .green {
+        color: _color(green, 500);
+      }
+    `);
+
+    expect(output.$('.blue').prop('color')).to.equal('#3197D6'.toLowerCase());
+    expect(output.$('.charcoal').prop('color')).to.equal('#394956'.toLowerCase());
+    expect(output.$('.grey').prop('color')).to.equal('#D6DDE3'.toLowerCase());
+    expect(output.$('.yellow').prop('color')).to.equal('#FFC646'.toLowerCase());
+    expect(output.$('.red').prop('color')).to.equal('#E52F28'.toLowerCase());
+    expect(output.$('.green').prop('color')).to.equal('#4BC27D'.toLowerCase());
+  });
+
+  it('should have brand namespaced colors', function() {
+    var output = styles(`
+      .brand {
+        color: _color(brand);
+      }
+    `);
+
+    expect(output.$('.brand').prop('color')).to.equal('#3197D6'.toLowerCase());
+  });
+
+  it('should have background namespaced colors', function() {
+    var output = styles(`
+      body {
+        background-color: _color(background, body);
+      }
+      .card {
+        color: _color(background, ui, light);
+      }
+    `);
+
+    expect(output.$('body').prop('background-color')).to.equal('#fff'.toLowerCase());
+    expect(output.$('.card').prop('color')).to.equal('#F1F3F5'.toLowerCase());
+  });
+
+  it('should have border namespaced colors', function() {
+    var output = styles(`
+      .card {
+        border-color: _color(border);
+      }
+    `);
+
+    expect(output.$('.card').prop('border-color')).to.equal('#E3E8EB'.toLowerCase());
+  });
+
+  it('should have text namespaced colors', function() {
+    var output = styles(`
+      .card {
+        color: _color(text);
+      }
+    `);
+
+    expect(output.$('.card').prop('color')).to.equal('#2A3B47'.toLowerCase());
+  });
+
+  it('should have state namespaced colors', function() {
+    var output = styles(`
+      .yiss {
+        color: _color(state, success, color);
+      }
+    `);
+
+    expect(output.$('.yiss').prop('color')).to.equal('#228350'.toLowerCase());
+  });
+});

--- a/test/color.scheme.js
+++ b/test/color.scheme.js
@@ -82,6 +82,7 @@ describe('seed-color-scheme: color: scheme', function() {
 
   it('should have state namespaced colors', function() {
     var output = styles(`
+      // https://media.giphy.com/media/S4P8Z5fiLRpOU/giphy.gif
       .yiss {
         color: _color(state, success, color);
       }


### PR DESCRIPTION
## Updates

* Update _config.scss to bring in colors from seed-colorscheme-helpscout to use as default colors
* Add namespaces for colors under brand, background, border, text, and states
* Add tests for new default colors and namespaces

Resolves: https://github.com/helpscout/seed-color-scheme/issues/4