### PR TITLE
Fix: Add default colors to the color palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,18 @@ Since [v0.1.0](https://github.com/helpscout/seed-color-scheme/releases/tag/v0.1.
   ),
 ));
 
+// Color defaults
+@include _color((
+  blue: (default: _color(blue, 500)),
+  charcoal: (default: _color(charcoal, 500)),
+  grey: (default: _color(grey, 500)),
+  yellow: (default: _color(yellow, 500)),
+  green: (default: _color(green, 500)),
+  red: (default: _color(red, 500)),
+  purple: (default: _color(purple, 500)),
+  orange: (default: _color(orange, 500)),
+));
+
 // Namespace: Brand
 @include _color((
   brand: (

--- a/scss/pack/seed-color-scheme/_config.scss
+++ b/scss/pack/seed-color-scheme/_config.scss
@@ -109,6 +109,18 @@
     ),
   ));
 
+  // Color defaults
+  @include _color((
+    blue: (default: _color(blue, 500)),
+    charcoal: (default: _color(charcoal, 500)),
+    grey: (default: _color(grey, 500)),
+    yellow: (default: _color(yellow, 500)),
+    green: (default: _color(green, 500)),
+    red: (default: _color(red, 500)),
+    purple: (default: _color(purple, 500)),
+    orange: (default: _color(orange, 500)),
+  ));
+
   // Namespace: Brand
   @include _color((
     brand: (

--- a/test/color.defaults.js
+++ b/test/color.defaults.js
@@ -1,0 +1,57 @@
+// Test :: Mixin/Function :: Color
+/* globals describe: true, it: true */
+'use strict';
+
+var expect = require('chai').expect;
+var styles = require('./helper.styles');
+
+describe('seed-color-scheme: color - defaults', function() {
+  it('should have default colors for all the main colors', function() {
+    var output = styles(`
+      .blue {
+        color: _color(blue);
+      }
+      .charcoal {
+        color: _color(charcoal);
+      }
+      .grey {
+        color: _color(grey);
+      }
+      .yellow {
+        color: _color(yellow);
+      }
+      .green {
+        color: _color(green);
+      }
+      .red {
+        color: _color(red);
+      }
+      .purple {
+        color: _color(purple);
+      }
+      .orange {
+        color: _color(orange);
+      }
+    `);
+
+    const colors = {
+      blue: '#3197D6',
+      charcoal: '#394956',
+      grey: '#D6DDE3',
+      yellow: '#FFC646',
+      green: '#4BC27D',
+      red: '#E52F28',
+      purple: '#7E80E7',
+      orange: '#FF9139',
+    };
+
+    expect(output.rule('.blue').prop('color')).to.equal(colors.blue.toLowerCase());
+    expect(output.rule('.charcoal').prop('color')).to.equal(colors.charcoal.toLowerCase());
+    expect(output.rule('.grey').prop('color')).to.equal(colors.grey.toLowerCase());
+    expect(output.rule('.yellow').prop('color')).to.equal(colors.yellow.toLowerCase());
+    expect(output.rule('.green').prop('color')).to.equal(colors.green.toLowerCase());
+    expect(output.rule('.red').prop('color')).to.equal(colors.red.toLowerCase());
+    expect(output.rule('.purple').prop('color')).to.equal(colors.purple.toLowerCase());
+    expect(output.rule('.orange').prop('color')).to.equal(colors.orange.toLowerCase());
+  });
+});


### PR DESCRIPTION
Previously, the main colors from blue -> orange were missing a `default` key.
This prevented the function of `_color(blue)` from working correctly.

This update adds the defaults to all the colors in the palette.
A test has been added as well.